### PR TITLE
Allow initial quantity of agent to be zero

### DIFF
--- a/src/java/org/demonsoft/spatialkappa/model/InitialValue.java
+++ b/src/java/org/demonsoft/spatialkappa/model/InitialValue.java
@@ -21,7 +21,7 @@ public class InitialValue {
         if (complexes == null || location == null) {
             throw new NullPointerException();
         }
-        if (complexes.size() == 0 || quantity <= 0) {
+        if (complexes.size() == 0 || quantity < 0) {
             throw new IllegalArgumentException();
         }
 


### PR DESCRIPTION
I'd like to be able to start off SpatialKappa simulations with zero quantities (for example of Ca, which may be added during the simulation). The attached patch allows me to do this - I don't think it has any adverse consequences.
