### PR TITLE
transitionInstance.activity should be long?

### DIFF
--- a/src/java/org/demonsoft/spatialkappa/model/TransitionInstance.java
+++ b/src/java/org/demonsoft/spatialkappa/model/TransitionInstance.java
@@ -9,7 +9,7 @@ public class TransitionInstance {
     public final List<ComplexMapping> sourceMapping;
     public final int targetLocationCount;
     public final Map<Complex, Integer> requiredComplexCounts = new HashMap<Complex, Integer>();
-    public int activity;
+    public long activity;
     public boolean isActivitySet = false;
     public float totalRate;
     

--- a/src/java/org/demonsoft/spatialkappa/tools/TransitionMatchingSimulation.java
+++ b/src/java/org/demonsoft/spatialkappa/tools/TransitionMatchingSimulation.java
@@ -404,7 +404,7 @@ public class TransitionMatchingSimulation implements Simulation, SimulationState
             else {
                 List<TransitionInstance> transitionInstances = transitionInstanceMap.get(transition);
                 for (TransitionInstance transitionInstance : transitionInstances) {
-                    int instanceActivity = getTransitionInstanceActivity(transitionInstance);
+                    long instanceActivity = getTransitionInstanceActivity(transitionInstance);
                     float instanceRate = getTransitionInstanceRate(transitionInstance, transition);
                     transitionInstance.totalRate = instanceActivity * instanceRate;
                     totalTransitionRate += transitionInstance.totalRate;
@@ -439,7 +439,7 @@ public class TransitionMatchingSimulation implements Simulation, SimulationState
     }
 
 
-    int getTransitionInstanceActivity(TransitionInstance transitionInstance) {
+    long getTransitionInstanceActivity(TransitionInstance transitionInstance) {
         if (!transitionInstance.isActivitySet) {
             throw new IllegalStateException();
         }


### PR DESCRIPTION
I'm trying some simulations with large numbers of molecules and have hit a problem that can be solved by making the transitionInstance.activity long rather than an int . Basically the problem is that in TransitionMatchingSimulation.updateTransitionInstanceActivity():

   result *= (availableCount--);

when performed on two large ints gives a negative int. This is solved by using a long for result (i.e. transitionInstance.activity).

I think it would be good to fix this, or at least have the code throw an exception when transitionInstance.activity is negative. What do you think?
